### PR TITLE
fix: change offset calculation order to work with prefix matches

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -185,15 +185,15 @@ impl TwoByteWM {
             if shift == 0 {
                 // We might have matched the end of some needle.  Iterate over all the needles
                 // that we might have matched, and see if they match the beginning.
-                let a = haystack[pos - pat_len + 1];
-                let b = haystack[pos - pat_len + 2];
+                let a = haystack[1 + pos - pat_len];
+                let b = haystack[2 + pos - pat_len];
                 let prefix = ((a as u16) << 8) + (b as u16);
                 let mut found: Option<NeedleIdx> = None;
                 for p_idx in self.hash[h]..self.hash[h+1] {
                     if self.prefix[p_idx as usize] == prefix {
                         // The prefix matches too, so now check for the full match.
                         let p = self.pat(p_idx);
-                        if haystack[(pos - pat_len + 1)..].starts_with(&p) {
+                        if haystack[(1 + pos - pat_len)..].starts_with(&p) {
                             found = match found {
                                 None => Some(p_idx),
                                 Some(q_idx) => {
@@ -206,8 +206,8 @@ impl TwoByteWM {
                 }
                 if let Some(p_idx) = found {
                     return Some(Match {
-                        start: pos - pat_len + 1,
-                        end: pos - pat_len + 1 + self.pat(p_idx).len(),
+                        start: 1 + pos - pat_len,
+                        end: 1 + pos - pat_len + self.pat(p_idx).len(),
                         pat_idx: self.pat_idx(p_idx),
                     })
                 }
@@ -260,6 +260,22 @@ mod tests {
                 .collect();
             assert_eq!(wm_answer, ac_answer);
         }
+    }
+
+    #[test]
+    fn match_at_beginning() {
+        let needles = vec![
+            "Hello world",
+            "it is a beautiful day",
+            "somewhere."
+        ];
+
+        let haystack = "it is a beautiful day in Cairo";
+        let wm = TwoByteWM::new(&needles);
+        let results = wm.find(haystack).collect::<Vec<_>>();
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].pat_idx, 1);
     }
 }
 


### PR DESCRIPTION
If a match was found exactly at the beginning of a haystack (see the new supplied test), the scanner would panic when trying to subtract `pat_len` from `pos`, as `pat_len` would always be larger than `pos` in this case.

-----------

In case you're wondering "Why is someone randomly sending a PR to this 7 year old, seemingly unmaintained repo?": We are working on a Rust implementation of Nix, called [Tvix](https://cs.tvl.fyi/depot/-/blob/tvix/README.md). In a part of this project we have a potentially huge number of *needles* which are all equal length, very random strings (hashes of other data), and need to find their occurences in a set of other matches. The set of needles frequently changes and we need to do this scanning hundreds/thousands of times during a single run.

Especially the fact that the set changes quickly makes automaton-based solutions fairly inefficient, as we're doing expensive construction and throwing them away all the time. We tried the famous `aho-corasick` Rust implementation - it increased runtime by 5x, and ended up being most of what the program did (apart from disk IO). After reading some of the literature, I found that the Wu-Manber algorithm is likely a good fit for our problem space, and your crate was the only one implementing it already (I wasn't quite convinced _enough_ to start a from-scratch implementation, though). It is *significantly* better performing for us already, but we had to squash this bug :)

Thanks for publishing this!